### PR TITLE
Use upstream worker-loader; Add webpack config for worker-loader.

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -241,6 +241,10 @@ module.exports = {
             ]
           },
           {
+            test: /\.worker\.js$/,
+            use: { loader: 'worker-loader' }
+          },
+          {
             test: /\.scss$/,
             use: [
               require.resolve('style-loader'),

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -260,6 +260,10 @@ module.exports = {
             // Note: this won't work without `new ExtractTextPlugin()` in `plugins`.
           },
           {
+            test: /\.worker\.js$/,
+            use: { loader: 'worker-loader' }
+          },
+          {
             test: /\.scss$/,
             use: [
               require.resolve('style-loader'),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baristalabs/react-scripts-ts",
-  "version": "2.10.6",
+  "version": "2.11.0",
   "description": "Configuration and scripts for Create React App.",
   "repository": "baristalabs/react-scripts-ts",
   "license": "MIT",
@@ -63,7 +63,7 @@
     "webpack-dev-server": "2.11.1",
     "webpack-manifest-plugin": "2.0.0-rc.2",
     "whatwg-fetch": "^2.0.3",
-    "worker-loader": "baristalabs/worker-loader",
+    "worker-loader": "^1.1.1",
     "write-file-webpack-plugin": "^4.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
A previous worker-loader fix that was required for Webpack 3.x support was left unpublished to npm at the time. Thus, a fork was created and referenced via the package.json. 

Since that time everything got resolved, but the fork never de-referenced.

This PR fixes this and starts using worker-loader on npm once again.