### PR TITLE
Revert usage of fork-ts-checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Enhancements over create-react-app-typescript:
 ---
  - Better Typescript Support via Awesome-Typescript-Loader & tslint support.
    - Note: some of the benefits of awesome-typescript-loader have been superceeded - both babel and fork checking is now in ts-loader, so... will re-evaluate later.
+   - fork-ts-checker-webpack-plugin doesn't seem to be picking up configuration and is looking at all files, not just /src/**.*
  - Polyfills via core.js
  - Additional loaders:
    - scss-loader (\*.scss and inline)

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -8,11 +8,12 @@ const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 const InterpolateHtmlPlugin = require('react-dev-utils/InterpolateHtmlPlugin');
 const WatchMissingNodeModulesPlugin = require('react-dev-utils/WatchMissingNodeModulesPlugin');
 const ModuleScopePlugin = require('react-dev-utils/ModuleScopePlugin');
-const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+//const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const getClientEnvironment = require('./env');
 const paths = require('./paths');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 const WriteFilePlugin = require("write-file-webpack-plugin");
+const { CheckerPlugin } = require('awesome-typescript-loader');
 
 // Webpack uses `publicPath` to determine where the app is being served from.
 // In development, we always serve from the root. This makes config easier.
@@ -331,12 +332,14 @@ module.exports = {
     // You can remove this if you don't use Moment.js:
     new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
     // Perform type checking and linting in a separate process to speed up compilation
-    new ForkTsCheckerWebpackPlugin({
-      async: false,
-      watch: paths.appSrc,
-      tsconfig: paths.appTsConfig,
-      tslint: paths.appTsLint,
-    }),
+    new CheckerPlugin(),
+    // ForkTsCheckerWebpackPlugin looks at ALL folders rather than just /src. doesn't seem to be config option to change.
+    // new ForkTsCheckerWebpackPlugin({
+    //   async: false,
+    //   watch: paths.appSrc,
+    //   tsconfig: paths.appTsConfig,
+    //   tslint: paths.appTsLint,
+    // }),
     //Write fields to the build folder during dev.
     new WriteFilePlugin(),
     // Set chunks -- remove in Webpack 4.x

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -14,6 +14,7 @@ const paths = require('./paths');
 const getClientEnvironment = require('./env');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+const { CheckerPlugin } = require('awesome-typescript-loader');
 
 // Webpack uses `publicPath` to determine where the app is being served from.
 // It requires a trailing slash, or the file assets will get an incorrect path.
@@ -417,11 +418,13 @@ module.exports = {
     // You can remove this if you don't use Moment.js:
     new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
     // Perform type checking and linting in a separate process to speed up compilation
-    new ForkTsCheckerWebpackPlugin({
-      async: false,
-      tsconfig: paths.appTsConfig,
-      tslint: paths.appTsLint,
-    }),
+    new CheckerPlugin(),
+    // ForkTsCheckerWebpackPlugin looks at ALL folders rather than just /src. doesn't seem to be config option to change.
+    // new ForkTsCheckerWebpackPlugin({
+    //   async: false,
+    //   tsconfig: paths.appTsConfig,
+    //   tslint: paths.appTsLint,
+    // }),
     // Use a hashed module id rather than resolving order
     new webpack.HashedModuleIdsPlugin(),
     // Set chunks -- remove in Webpack 4.x

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baristalabs/react-scripts-ts",
-  "version": "2.11.3",
+  "version": "2.11.4",
   "description": "Configuration and scripts for Create React App.",
   "repository": "baristalabs/react-scripts-ts",
   "license": "MIT",


### PR DESCRIPTION
Unfortunately fork-ts-checker-webpack-plugin isn't finding tsconfig.json and tslint.json and as such attempting to lint everything in the application folder.